### PR TITLE
Reintroduce ListBaseResponse with JsonIgnore attribute

### DIFF
--- a/PayarcSDK/Entities/ListBaseResponse.cs
+++ b/PayarcSDK/Entities/ListBaseResponse.cs
@@ -11,7 +11,8 @@ public abstract class ListBaseResponse
     [JsonProperty("pagination")]
     public virtual Dictionary<string, object>? Pagination { get; set; }
 
-    public string? RawData { get; set; }
+	[JsonIgnore]
+	public string? RawData { get; set; }
         
     public override string ToString()
     {


### PR DESCRIPTION
The `ListBaseResponse` class has been reintroduced in the `PayarcSDK.Entities` namespace. The `RawData` property is now marked with the `[JsonIgnore]` attribute to prevent it from being serialized to JSON, improving control over the serialization process.