### PR TITLE
Add User-Agent header to HTTP client in PayarcSDK

### DIFF
--- a/PayarcSDK/SDKBuilder.cs
+++ b/PayarcSDK/SDKBuilder.cs
@@ -53,7 +53,7 @@ namespace PayarcSDK {
             // Add the Authorization header with Bearer token
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _config.BearerToken);
 
-			var userAgent = $"sdk-nodejs/{_config.ApiVersion}";
+			var userAgent = $"sdk-csharp/{_config.ApiVersion}";
 			if (!httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd(userAgent)) {
 				throw new InvalidOperationException("Invalid User-Agent header value.");
 			}

--- a/PayarcSDK/SDKBuilder.cs
+++ b/PayarcSDK/SDKBuilder.cs
@@ -53,8 +53,13 @@ namespace PayarcSDK {
             // Add the Authorization header with Bearer token
             httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _config.BearerToken);
 
-            // Return the Payarc instance (facade for all services)
-            return new Payarc(httpClient, _config);
+			var userAgent = $"sdk-nodejs/{_config.ApiVersion}";
+			if (!httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd(userAgent)) {
+				throw new InvalidOperationException("Invalid User-Agent header value.");
+			}
+
+			// Return the Payarc instance (facade for all services)
+			return new Payarc(httpClient, _config);
         }
     }
 }


### PR DESCRIPTION
This update introduces a User-Agent header to the HTTP client, formatting it with the SDK version. It includes a check to ensure the User-Agent can be added, throwing an `InvalidOperationException` if not. The comment regarding the return of the Payarc instance has been repositioned, but the functionality remains unchanged.