### PR TITLE
Add charge listing methods for agents in ApiRequester

### DIFF
--- a/PayarcSDK.Sample/ApiRequester.cs
+++ b/PayarcSDK.Sample/ApiRequester.cs
@@ -227,6 +227,70 @@ public class ApiRequester {
 		}
 
 	}
+	public async Task ListByAgentPayfac() {
+		try {
+			var options = new BaseListOptions() {
+				Limit = 25,
+				Page = 1,
+			};
+			var responseData = await _payarc.Charges.ListByAgentPayfac(options);
+			Console.WriteLine(JsonConvert.SerializeObject(responseData, new JsonSerializerSettings {
+				NullValueHandling = NullValueHandling.Ignore,
+				Formatting = Formatting.Indented
+			}));
+
+			//Console.WriteLine("Charges Data");
+			//for (int i = 0; i < responseData?.Data?.Count; i++) {
+			//	var t = responseData.Data[i];
+			//	Console.WriteLine(responseData.Data[i]);
+			//}
+			//Console.WriteLine("Pagination Data");
+			//Console.WriteLine(responseData?.Pagination["total"]);
+			//Console.WriteLine(responseData?.Pagination["count"]);
+			//Console.WriteLine(responseData?.Pagination["per_page"]);
+			//Console.WriteLine(responseData?.Pagination["current_page"]);
+			//Console.WriteLine(responseData?.Pagination["total_pages"]);
+			// Console.WriteLine("Raw Data");
+			// Console.WriteLine(responseData?.RawData);
+		} catch (Exception e) {
+			Console.WriteLine(e);
+			throw;
+		}
+
+	}
+	public async Task ListByAgentTraditional(BaseListOptions? options = null) {
+		try {
+			if (options == null) {
+				options = new BaseListOptions() {
+					Limit = 25,
+					Page = 1
+				};
+			}
+			var responseData = await _payarc.Charges.ListsByAgentTraditional(options);
+			Console.WriteLine(JsonConvert.SerializeObject(responseData, new JsonSerializerSettings {
+				NullValueHandling = NullValueHandling.Ignore,
+				Formatting = Formatting.Indented
+			}));
+
+			//Console.WriteLine("Charges Data");
+			//for (int i = 0; i < responseData?.Data?.Count; i++) {
+			//	var t = responseData.Data[i];
+			//	Console.WriteLine(responseData.Data[i]);
+			//}
+			//Console.WriteLine("Pagination Data");
+			//Console.WriteLine(responseData?.Pagination["total"]);
+			//Console.WriteLine(responseData?.Pagination["count"]);
+			//Console.WriteLine(responseData?.Pagination["per_page"]);
+			//Console.WriteLine(responseData?.Pagination["current_page"]);
+			//Console.WriteLine(responseData?.Pagination["total_pages"]);
+			// Console.WriteLine("Raw Data");
+			// Console.WriteLine(responseData?.RawData);
+		} catch (Exception e) {
+			Console.WriteLine(e);
+			throw;
+		}
+
+	}
 	public async Task CreatePlan() {
 		try {
 			var options = new PlanCreateOptions() {

--- a/PayarcSDK.Sample/Program.cs
+++ b/PayarcSDK.Sample/Program.cs
@@ -63,7 +63,7 @@ namespace PayarcSDK.Sample {
 			try {
 				payarcAgent = new SdkBuilder()
 					.Configure(config => {
-						config.Environment = "sandbox";         // Use sandbox environment
+						//config.Environment = "sandbox";         // Use sandbox environment
 						config.ApiVersion = "v1";               // Use version 2 of the API
 						config.BearerToken = agentAccessToken;  // Set the Bearer Token
 					})
@@ -167,8 +167,8 @@ namespace PayarcSDK.Sample {
 			//var testService = "customerService";
 			//var testService = "applicationService";
 			//var testService = "disputeService";
-			var testService = "splitCampaignService";
-			//var testService = "chargeService";
+			//var testService = "splitCampaignService";
+			var testService = "chargeService";
 			//var testService = "payarcConnect";
 			var apiRequester = new ApiRequester(payarc);
 			var apiAgentRequester = new ApiRequester(payarcAgent);
@@ -599,9 +599,22 @@ namespace PayarcSDK.Sample {
 						// await apiRequester.CreateACHChargeByBankAccount();
 						// await apiRequester.CreateACHChargeByBankAccountDetails();
 						// await apiRequester.ListCharges();
-						 await apiRequester.RefundChargeById();
+						// await apiRequester.RefundChargeById();
 						// await apiRequester.RefundChargeByObject();
 						// await apiRequester.RefundACHChargeByObject();
+						// await apiAgentRequester.ListByAgentPayfac();
+
+						var currentDateForCharges = DateTime.UtcNow;
+						var tomorrowDateForCharges = currentDateForCharges.AddDays(1).ToString("yyyy-MM-dd");
+						//var lastMonthDateForCharges = currentDateForCharges.AddMonths(-1).ToString("yyyy-MM-dd");
+						var lastMonthDateForCharges = currentDateForCharges.AddDays(-1).ToString("yyyy-MM-dd");
+
+						BaseListOptions queryParamsAgentTraditionalCharges = new BaseListOptions {
+							From_Date = lastMonthDateForCharges,
+							To_Date = tomorrowDateForCharges,
+						};
+						await apiAgentRequester.ListByAgentTraditional(queryParamsAgentTraditionalCharges);
+						await apiAgentRequester.ListByAgentTraditional();
 						break;
 					case "billingService":
 						// await apiRequester.CreatePlan();

--- a/PayarcSDK/Entities/BaseListOptions.cs
+++ b/PayarcSDK/Entities/BaseListOptions.cs
@@ -9,4 +9,7 @@ public class BaseListOptions
 
 	public string? Report_DateGTE { get; init; }
 	public string? Report_DateLTE { get; init; }
+
+	public string? From_Date { get; init; }
+	public string? To_Date { get; init; }
 }

--- a/PayarcSDK/Services/ChargeService.cs
+++ b/PayarcSDK/Services/ChargeService.cs
@@ -119,9 +119,46 @@ namespace PayarcSDK.Services
                 Console.WriteLine(ex);
                 throw;
             }
-        }
+		}
 
-        private async Task<ListBaseResponse?> GetChargesAsync(string endpoint, string? queryParams, string type = "Charge")
+		public async Task<ListBaseResponse?> ListByAgentPayfac(BaseListOptions? options = null) {
+			try {
+				var parameters = new Dictionary<string, object?>
+					{
+						{ "limit", options?.Limit ?? 25 },
+						{ "page", options?.Page ?? 1 },
+						{ "search", options?.Search }
+					}.Where(kvp => kvp.Value != null)
+					.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+				var query = BuildQueryString(parameters);
+				return await ListChargesByAgentPayfac("agent-hub/merchant-bridge/charges", query);
+			} catch (Exception ex) {
+				Console.WriteLine(ex);
+				throw;
+			}
+		}
+
+		public async Task<ListBaseResponse?> ListsByAgentTraditional(BaseListOptions? options = null) {
+			try {
+				var parameters = new Dictionary<string, object?>
+					{
+						{ "limit", options?.Limit ?? 25 },
+						{ "page", options?.Page ?? 1 },
+						{ "from_date", options?.From_Date },
+						{ "to_date", options?.To_Date }
+					}.Where(kvp => kvp.Value != null)
+					.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+				var query = BuildQueryString(parameters);
+				return await ListChargesByAgentTraditional("agent/charges", query);
+			} catch (Exception ex) {
+				Console.WriteLine(ex);
+				throw;
+			}
+		}
+
+		private async Task<ListBaseResponse?> GetChargesAsync(string endpoint, string? queryParams, string type = "Charge")
         {
             try
             {
@@ -196,9 +233,133 @@ namespace PayarcSDK.Services
                 Console.WriteLine($"General error handling charge: {ex.Message}");
                 throw;
             }
-        }
+		}
 
-        private Dictionary<string, string> GetParams(string endpoint)
+		private async Task<ListBaseResponse?> ListChargesByAgentPayfac(string endpoint, string? queryParams, string type = "Charge") {
+			try {
+				var url = $"{endpoint}?{queryParams}";
+				var request = new HttpRequestMessage(HttpMethod.Get, url);
+				var response = await _httpClient.SendAsync(request);
+				var responseBody = await response.Content.ReadAsStringAsync();
+				Console.WriteLine($"Response status code: {response.StatusCode}");
+				if (!response.IsSuccessStatusCode) {
+					var errorData = JsonSerializer.Deserialize<Dictionary<string, object>>(responseBody);
+					Console.WriteLine($"Error details: {JsonSerializer.Serialize(errorData)}");
+					throw new InvalidOperationException($"HTTP error {response.StatusCode}: {responseBody}");
+				}
+
+				if (string.IsNullOrWhiteSpace(responseBody)) {
+					throw new InvalidOperationException("Response body is empty.");
+				}
+
+				var responseData = JsonSerializer.Deserialize<Dictionary<string, object>>(responseBody);
+				if (responseData == null || !responseData.TryGetValue("data", out var dataValue) ||
+					!(dataValue is JsonElement dataElement)) {
+					throw new InvalidOperationException("Response data is invalid or missing.");
+				}
+
+				var rawData = dataElement.GetRawText();
+				var jsonCharges = dataElement.Deserialize<List<Dictionary<string, object>>>();
+				List<BaseResponse?>? charges = new List<BaseResponse?>();
+				if (jsonCharges != null) {
+					for (int i = 0; i < jsonCharges.Count; i++) {
+						var ch = TransformJsonRawObject(jsonCharges[i], JsonSerializer.Serialize(jsonCharges[i]), type);
+						charges?.Add(ch);
+					}
+				}
+
+				var pagination = new Dictionary<string, object>();
+				if (responseData.TryGetValue("meta", out var metaValue) && metaValue is JsonElement metaElement) {
+					var paginationElement = metaElement.GetProperty("pagination");
+					pagination["total"] = paginationElement.GetProperty("total").GetInt32();
+					pagination["count"] = paginationElement.GetProperty("count").GetInt32();
+					pagination["per_page"] = paginationElement.GetProperty("per_page").GetInt32();
+					pagination["current_page"] = paginationElement.GetProperty("current_page").GetInt32();
+					pagination["total_pages"] = paginationElement.GetProperty("total_pages").GetInt32();
+				}
+
+				pagination?.Remove("links");
+
+				return new ChargeListResponse {
+					Data = charges,
+					Pagination = pagination,
+					RawData = rawData
+				};
+			} catch (HttpRequestException ex) {
+				Console.WriteLine($"HTTP error processing charge: {ex.Message}");
+				throw;
+			} catch (JsonException ex) {
+				Console.WriteLine($"JSON error processing charge: {ex.Message}");
+				throw new InvalidOperationException("Failed to process JSON response.", ex);
+			} catch (Exception ex) {
+				Console.WriteLine($"General error handling charge: {ex.Message}");
+				throw;
+			}
+		}
+
+		private async Task<ListBaseResponse?> ListChargesByAgentTraditional(string endpoint, string? queryParams, string type = "Charge") {
+			try {
+				var url = $"{endpoint}?{queryParams}";
+				var request = new HttpRequestMessage(HttpMethod.Get, url);
+				var response = await _httpClient.SendAsync(request);
+				var responseBody = await response.Content.ReadAsStringAsync();
+				Console.WriteLine($"Response status code: {response.StatusCode}");
+				if (!response.IsSuccessStatusCode) {
+					var errorData = JsonSerializer.Deserialize<Dictionary<string, object>>(responseBody);
+					Console.WriteLine($"Error details: {JsonSerializer.Serialize(errorData)}");
+					throw new InvalidOperationException($"HTTP error {response.StatusCode}: {responseBody}");
+				}
+
+				if (string.IsNullOrWhiteSpace(responseBody)) {
+					throw new InvalidOperationException("Response body is empty.");
+				}
+
+				var responseData = JsonSerializer.Deserialize<Dictionary<string, object>>(responseBody);
+				if (responseData == null || !responseData.TryGetValue("data", out var dataValue) ||
+					!(dataValue is JsonElement dataElement)) {
+					throw new InvalidOperationException("Response data is invalid or missing.");
+				}
+
+				var rawData = dataElement.GetRawText();
+				var jsonCharges = dataElement.Deserialize<List<Dictionary<string, object>>>();
+				List<BaseResponse?>? charges = new List<BaseResponse?>();
+				if (jsonCharges != null) {
+					for (int i = 0; i < jsonCharges.Count; i++) {
+						var ch = TransformJsonRawObject(jsonCharges[i], JsonSerializer.Serialize(jsonCharges[i]), type);
+						charges?.Add(ch);
+					}
+				}
+
+				var pagination = new Dictionary<string, object>();
+				if (responseData.TryGetValue("meta", out var metaValue) && metaValue is JsonElement metaElement) {
+					var paginationElement = metaElement.GetProperty("pagination");
+					pagination["total"] = paginationElement.GetProperty("total").GetInt32();
+					pagination["count"] = paginationElement.GetProperty("count").GetInt32();
+					pagination["per_page"] = paginationElement.GetProperty("per_page").GetInt32();
+					pagination["current_page"] = paginationElement.GetProperty("current_page").GetInt32();
+					pagination["total_pages"] = paginationElement.GetProperty("total_pages").GetInt32();
+				}
+
+				pagination?.Remove("links");
+
+				return new ChargeListResponse {
+					Data = charges,
+					Pagination = pagination,
+					RawData = rawData
+				};
+			} catch (HttpRequestException ex) {
+				Console.WriteLine($"HTTP error processing charge: {ex.Message}");
+				throw;
+			} catch (JsonException ex) {
+				Console.WriteLine($"JSON error processing charge: {ex.Message}");
+				throw new InvalidOperationException("Failed to process JSON response.", ex);
+			} catch (Exception ex) {
+				Console.WriteLine($"General error handling charge: {ex.Message}");
+				throw;
+			}
+		}
+
+		private Dictionary<string, string> GetParams(string endpoint)
         {
             if (endpoint == "charges")
             {

--- a/README.md
+++ b/README.md
@@ -257,6 +257,32 @@ try {
 }
 ```
 
+## Listing Charges by Agent
+
+### Example: List Charges with No Constraints by Agent (Payfac)
+
+This example demonstrates how to list all charges by agent without any constraints:
+```csharp
+try {
+    var charges = await payarc.Charges.ListByAgentPayfac();
+    Console.WriteLine($"Charges list (Payfac): {JsonSerializer.Serialize(charges)}");
+} catch (Exception ex) {
+    Console.WriteLine($"Error detected: {ex.Message}");
+}
+```
+
+### Example: List Charges with Constraints by Agent (Traditional)
+
+This example demonstrates how to list all charges by agent with date constraints:
+```csharp
+try {
+    var charges = await payarc.Charges.ListsByAgentTraditional();
+    Console.WriteLine($"Charges list (Traditional): {JsonSerializer.Serialize(charges)}");
+} catch (Exception ex) {
+    Console.WriteLine($"Error detected: {ex.Message}");
+}
+```
+
 ## Refunding a Charge
 
 ### Example: Refund a Charge


### PR DESCRIPTION
Updated the ApiRequester class with ListByAgentPayfac and ListByAgentTraditional methods for retrieving charges by agent type. Modified Program.cs to switch the testService and demonstrate the new methods. Extended BaseListOptions to include From_Date and To_Date for date filtering. Added corresponding methods in ChargeService.cs to handle API requests and error management. Updated README.md with usage examples for the new functionality.