### PR TITLE
Refactor batch retrieval to use BatchDetailRequestData

### DIFF
--- a/PayarcSDK/Entities/BaseListOptions.cs
+++ b/PayarcSDK/Entities/BaseListOptions.cs
@@ -12,7 +12,4 @@ public class BaseListOptions
 
 	public string? From_Date { get; init; }
 	public string? To_Date { get; init; }
-	public string? Merchant_Account_Number { get; init; }
-	public string? Reference_Number { get; init; }
-	public string? Date { get; init; }
 }

--- a/PayarcSDK/Entities/Batch/BatchDetailRequestData.cs
+++ b/PayarcSDK/Entities/Batch/BatchDetailRequestData.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PayarcSDK.Entities.Batch {
+	public class BatchDetailRequestData {
+		public string? Merchant_Account_Number { get; init; }
+		public string? Reference_Number { get; init; }
+		public string? Date { get; init; }
+	}
+}

--- a/PayarcSDK/Services/BatchService.cs
+++ b/PayarcSDK/Services/BatchService.cs
@@ -37,17 +37,19 @@ namespace PayarcSDK.Services
 			}
 		}
 
-		public async Task<ListBaseResponse?> Retrieve(BaseListOptions? options = null) {
+		public async Task<ListBaseResponse?> Retrieve(BatchDetailRequestData? batchDetailData = null) {
 			try {
+				var refNum = batchDetailData?.Reference_Number;
+				refNum = refNum.StartsWith("brn_") ? refNum.Substring(4) : refNum;
 				var parameters = new Dictionary<string, object?>
 					{
-						{ "reference_number", options?.Reference_Number },
-						{ "date", options?.Date }
+						{ "reference_number", refNum },
+						{ "date", batchDetailData?.Date }
 					}.Where(kvp => kvp.Value != null)
 					.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
 				var query = BuildQueryString(parameters);
-				return await ListBatchReportDetailsByAgent("agent/batch/reports/details/" + options?.Merchant_Account_Number, query);
+				return await ListBatchReportDetailsByAgent("agent/batch/reports/details/" + batchDetailData?.Merchant_Account_Number, query);
 			} catch (Exception ex) {
 				Console.WriteLine(ex);
 				throw;


### PR DESCRIPTION
- Removed `Merchant_Account_Number`, `Reference_Number`, and `Date` from `BaseListOptions`.
- Updated `Retrieve` method in `BatchService.cs` to accept `BatchDetailRequestData?` instead of `BaseListOptions?`.
- Adjusted query parameter construction to use properties from `BatchDetailRequestData`.
- Added new class `BatchDetailRequestData` to encapsulate batch detail request data.